### PR TITLE
Fix variable definition text

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -104,7 +104,7 @@ Required Variables (`variable.tf`)
 
 ### Variable Definitions
 
-Define your variables in the `terraform.tfvars` file or pass them via command-line or environment variables.Example `terraform.tfvars`:**
+Define your variables in the `terraform.tfvars` file or pass them via command-line or environment variables. Example `terraform.tfvars`:
 
 ```hcl
 s3_bucket_name         = "your-bucket-name"


### PR DESCRIPTION
## Summary
- fix stray formatting and missing space in variable definitions line

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684466f434f08326a800c0ca6db22008